### PR TITLE
Delete parcel crash bug fix

### DIFF
--- a/app/src/main/java/com/nitramite/paketinseuranta/DatabaseHelper.java
+++ b/app/src/main/java/com/nitramite/paketinseuranta/DatabaseHelper.java
@@ -310,14 +310,16 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     // Get all package data
     public Cursor getAllDataWithLatestEvent() {
         SQLiteDatabase db = this.getReadableDatabase();
-        Cursor res = db.rawQuery("SELECT p." + KEY_ID + ", " + "p." + TRACKINGCODE + ", " +
+        String query = "SELECT p." + KEY_ID + ", " + "p." + TRACKINGCODE + ", " +
                 "p." + PHASE + ", " + "p." + FI + ", " + "p." + TITLE + ", " + "p." + LAST_UPDATE_STATUS + ", " +
                 "(SELECT " + DESCRIPTION + " FROM " + EVENTS_TABLE + " WHERE " + PARCEL_ID + " = " + "p." + KEY_ID + " ORDER BY " + TIMESTAMP_SQLITE + " DESC LIMIT 1" + ")" + " AS " + DESCRIPTION +
                 ", " + "p." + CARRIER + ", " + "p." + SENDER_TEXT + ", " + "p." + DELIVERY_METHOD + ", " + "p." + ADDITIONAL_NOTE + ", " + "p." + CREATE_DATE +
-                ", " + "p." + LASTPICKUPDATE +
+                ", " + "p." + LASTPICKUPDATE + ", " +
+                "(SELECT " + TIMESTAMP + " FROM " + EVENTS_TABLE + " WHERE " + PARCEL_ID + " = " + "p." + KEY_ID + " ORDER BY " + TIMESTAMP_SQLITE + " DESC LIMIT 1" + ")" + " AS " + "latestParcelEvent" +
                 " FROM " + PARCELS_TABLE + " AS p " +
-                " WHERE " + "p." + IS_ARCHIVED + " = '0'" + " ORDER BY " + "p." + PHASE_NUMBER + " DESC", null);
-        return res;
+                " WHERE " + "p." + IS_ARCHIVED + " = '0'" + " ORDER BY " + "p." + PHASE_NUMBER + " DESC";
+        Log.i(TAG, query);
+        return db.rawQuery(query, null);
     }
 
 
@@ -784,24 +786,6 @@ public class DatabaseHelper extends SQLiteOpenHelper {
         Cursor res = db.rawQuery("SELECT " + DESCRIPTION + " FROM " + EVENTS_TABLE + " WHERE " + PARCEL_ID + " = " + parcelID + " ORDER BY " + TIMESTAMP_SQLITE + " DESC LIMIT 1", null);
         res.moveToFirst();
         final String latestParcelEvent = res.getString(0);
-        res.close();
-        db.close();
-        return latestParcelEvent;
-    }
-
-    // Return parcel latest event for parcel id
-    public String getLatestParcelEventDate(String parcelID) {
-        Log.e(TAG, parcelID);
-        SQLiteDatabase db = this.getReadableDatabase();
-        Cursor res = db.rawQuery("SELECT " + TIMESTAMP + " FROM " + EVENTS_TABLE + " WHERE " + PARCEL_ID + " = " + parcelID + " ORDER BY " + TIMESTAMP_SQLITE + " DESC LIMIT 1", null);
-        res.moveToFirst();
-        if (res.getCount() < 1) {
-            res.close();
-            db.close();
-            return null;
-        }
-        final String latestParcelEvent = res.getString(0);
-        Log.e(TAG, latestParcelEvent);
         res.close();
         db.close();
         return latestParcelEvent;

--- a/app/src/main/java/com/nitramite/paketinseuranta/MainMenu.java
+++ b/app/src/main/java/com/nitramite/paketinseuranta/MainMenu.java
@@ -23,7 +23,6 @@ import android.content.pm.ActivityInfo;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.database.Cursor;
-import android.database.CursorIndexOutOfBoundsException;
 import android.graphics.Color;
 import android.net.Uri;
 import android.os.Build;
@@ -59,7 +58,6 @@ import com.android.billingclient.api.BillingResult;
 import com.android.billingclient.api.Purchase;
 import com.android.billingclient.api.PurchasesUpdatedListener;
 import com.android.billingclient.api.SkuDetailsParams;
-
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.google.android.material.snackbar.Snackbar;
 import com.nitramite.adapters.CustomEventsRecyclerViewAdapter;
@@ -479,28 +477,23 @@ public class MainMenu extends AppCompatActivity implements SwipeActionAdapter.Sw
     private void readItems() {
         parcelItems.clear();
         Cursor res = databaseHelper.getAllDataWithLatestEvent();
-        try {
-            while (res.moveToNext()) {
-                parcelItems.add(new ParcelItem(
-                        res.getString(0),
-                        res.getString(1),
-                        res.getString(2),
-                        res.getString(3),
-                        res.getString(4),
-                        res.getString(5),       // Last update status
-                        res.getString(6),       // Latest event description
-                        res.getString(7),       // Parcel carrier
-                        res.getString(8),
-                        res.getString(9),
-                        res.getString(10),
-                        res.getString(11),
-                        res.getString(12),       // Last pickup date
-                        databaseHelper.getLatestParcelEventDate(res.getString(0)) // Last event date
-                ));
-                Log.e(TAG, "Item led: " + parcelItems.get(parcelItems.size() - 1).getLastEventDate());
-            }
-        } catch (CursorIndexOutOfBoundsException e) {
-            Log.e(TAG, e.toString());
+        while (res.moveToNext()) {
+            parcelItems.add(new ParcelItem(
+                    res.getString(0),
+                    res.getString(1),
+                    res.getString(2),
+                    res.getString(3),
+                    res.getString(4),
+                    res.getString(5),       // Last update status
+                    res.getString(6),       // Latest event description
+                    res.getString(7),       // Parcel carrier
+                    res.getString(8),
+                    res.getString(9),
+                    res.getString(10),
+                    res.getString(11),
+                    res.getString(12),      // Last pickup date
+                    res.getString(13)       // Last event date
+            ));
         }
         updateListView();
     }

--- a/app/src/main/java/com/nitramite/paketinseuranta/Parcel.java
+++ b/app/src/main/java/com/nitramite/paketinseuranta/Parcel.java
@@ -26,7 +26,6 @@ import android.content.SharedPreferences;
 import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
 import android.database.Cursor;
-import android.database.CursorIndexOutOfBoundsException;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Color;
@@ -417,30 +416,24 @@ public class Parcel extends AppCompatActivity implements OnMapReadyCallback, Swi
      */
     private ArrayList<ParcelItem> getParcelItems() {
         ArrayList<ParcelItem> parcelItems = new ArrayList<>();
-        try {
-            Cursor res = databaseHelper.getAllDataWithLatestEvent();
-            String date = databaseHelper.getLatestParcelEventDate(res.getString(0));
-            while (res.moveToNext()) {
-                parcelItems.add(new ParcelItem(
-                        res.getString(0),
-                        res.getString(1),
-                        res.getString(2),
-                        res.getString(3),
-                        res.getString(4),
-                        res.getString(5),   // Last update status
-                        res.getString(6),   // Latest event description
-                        res.getString(7),   // Carrier
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        date
-                ));
-            }
-        } catch (CursorIndexOutOfBoundsException e) {
-            Parcel.this.finish();
-            Log.e(TAG, e.toString());
+        Cursor res = databaseHelper.getAllDataWithLatestEvent();
+        while (res.moveToNext()) {
+            parcelItems.add(new ParcelItem(
+                    res.getString(0),
+                    res.getString(1),
+                    res.getString(2),
+                    res.getString(3),
+                    res.getString(4),
+                    res.getString(5),   // Last update status
+                    res.getString(6),   // Latest event description
+                    res.getString(7),   // Carrier
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    res.getString(13)   // Latest parcel event date
+            ));
         }
         return parcelItems;
     }


### PR DESCRIPTION
When on parcel details view and when clicking remove parcel, app will crash after deletion dialog and parcel is not gone. Deletion worked only with swipe deletion but not from this side menu.

Added try catch to be more broader and if landing with CursorIndexOutOfBoundsException exception, will just finish activity.