### PR TITLE
Fix 4px with non https api

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,7 +22,9 @@
         android:roundIcon="@mipmap/ps_logo_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
-        tools:ignore="GoogleAppIndexingWarning">
+        tools:ignore="GoogleAppIndexingWarning"
+        android:networkSecurityConfig="@xml/network_security_config"
+        tools:targetApi="n">
 
         <uses-library
             android:name="org.apache.http.legacy"
@@ -74,7 +76,7 @@
              Note that the API key is linked to the encryption key used to sign the APK.
              You need a different API key for each encryption key, including the release key that is used to
              sign the APK for publishing.
-             You can define the keys for the debug and release targets in src/debug/ and src/release/. 
+             You can define the keys for the debug and release targets in src/debug/ and src/release/.
         -->
         <meta-data
             android:name="com.google.android.geo.API_KEY"

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">track.4px.com</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
Added typical fix -> network security config because 4px seems not to have https API, so this was only way.

<img width="912" alt="Screenshot 2020-09-02 at 20 55 56" src="https://user-images.githubusercontent.com/55850510/92019095-ba81d100-ed5e-11ea-81ed-06ac38e5590f.png">

Better do this way than set hack flag allow all un secure traffic everywhere.