### PR TITLE
Fix status handling at CustomParcelsAdapterV2

### DIFF
--- a/app/src/main/java/com/nitramite/adapters/CustomParcelsAdapterV2.java
+++ b/app/src/main/java/com/nitramite/adapters/CustomParcelsAdapterV2.java
@@ -103,10 +103,10 @@ public class CustomParcelsAdapterV2 extends ArrayAdapter<ParcelItem> {
 
 
         String phase = parcelItem.getParcelPhase();
-
         int pos = 1;
         final String latestEventDescription = (parcelItem.getParcelLatestEventDescription() != null ?
-                parcelItem.getParcelLatestEventDescription() : ""); // Latest event
+                parcelItem.getParcelLatestEventDescription() : "");
+
         phaseTextFix = context.getString(R.string.package_not_found);
 
         // Check for item in transit
@@ -123,28 +123,24 @@ public class CustomParcelsAdapterV2 extends ArrayAdapter<ParcelItem> {
         } else if (phase.length() == 12) {
             pos = 3;
             phaseTextFix = context.getString(R.string.status_in_transit);
-        } else if (phase.length() == 16 || latestEventDescription.contains("ilmoitus tekstiviestillä") || latestEventDescription.contains("toimitettu noutopisteeseen")) {
+        } else if (phase.length() == 16) {
             pos = 4;
             phaseTextFix = context.getString(R.string.status_ready);
         } else if (phase.length() == 8 || phase.equals("RETURNED_TO_SENDER")) {
             pos = 7;
             phaseTextFix = context.getString(R.string.status_returned);
-        } else //noinspection ConstantConditions
-            if (phase.length() == 7 || phase.equals("CUSTOMS")) {
-                pos = 8;
-                phaseTextFix = context.getString(R.string.status_customs);
-            }
-            // Not inside Finland
-            else if (phase.length() == 24 || latestEventDescription.equals("Lähetys ei ole vielä saapunut Postille, odotathan") ||
-                    latestEventDescription.equals("Lähetys on saapunut varastolle") || latestEventDescription.equals("Lähetys on lähtenyt varastolta")
-                    || latestEventDescription.equals("Lähetys on rekisteröity.") || latestEventDescription.equals("Lähetys on matkalla kohdemaahan")
-            ) {
-                pos = 2;
-                phaseTextFix = context.getString(R.string.status_in_transit);
-            } else if (parcelItem.getParcelCarrier().equals("99") && phase.equals("")) {
-                pos = 6;
-                phaseTextFix = "";
-            }
+        } else if (phase.length() == 7) {
+            pos = 8;
+            phaseTextFix = context.getString(R.string.status_customs);
+        }
+        // Not inside Finland
+        else if (phase.length() == 24) {
+            pos = 2;
+            phaseTextFix = context.getString(R.string.status_in_transit);
+        } else if (parcelItem.getParcelCarrier().equals("99") && phase.equals("")) {
+            pos = 6;
+            phaseTextFix = "";
+        }
 
         // -----------------------------------------------------------------------------------------
         /* Set values */

--- a/app/src/main/java/com/nitramite/adapters/CustomParcelsAdapterV2.java
+++ b/app/src/main/java/com/nitramite/adapters/CustomParcelsAdapterV2.java
@@ -110,7 +110,10 @@ public class CustomParcelsAdapterV2 extends ArrayAdapter<ParcelItem> {
         phaseTextFix = context.getString(R.string.package_not_found);
 
         // Check for item in transit
-        if (phase.equals(PhaseNumber.PHASE_WAITING_FOR_PICKUP)) {
+        if (phase.length() == 9) {
+            pos = 5;
+            phaseTextFix = context.getString(R.string.status_delivered);
+        } else if (phase.equals(PhaseNumber.PHASE_WAITING_FOR_PICKUP)) {
             // TODO made new icon. if it's good, let's use that in upcoming ones, as it's SVG not png
             pos = 9;
             phaseTextFix = context.getString(R.string.status_waiting_for_pickup);
@@ -123,9 +126,6 @@ public class CustomParcelsAdapterV2 extends ArrayAdapter<ParcelItem> {
         } else if (phase.length() == 16 || latestEventDescription.contains("ilmoitus tekstiviestillä") || latestEventDescription.contains("toimitettu noutopisteeseen")) {
             pos = 4;
             phaseTextFix = context.getString(R.string.status_ready);
-        } else if (phase.length() == 9) {
-            pos = 5;
-            phaseTextFix = context.getString(R.string.status_delivered);
         } else if (phase.length() == 8 || phase.equals("RETURNED_TO_SENDER")) {
             pos = 7;
             phaseTextFix = context.getString(R.string.status_returned);

--- a/app/src/main/java/com/nitramite/paketinseuranta/PhaseNumber.java
+++ b/app/src/main/java/com/nitramite/paketinseuranta/PhaseNumber.java
@@ -27,7 +27,13 @@ public class PhaseNumber {
     // Returns number equivalent for phase string
     public static PhaseNumberString phaseToNumber(final String phase, final String lastEventStr) {
 
-        if (phase.equals("IN_TRANSPORT_NOT_IN_FINLAND")) {
+        if (phase.equals("IN_TRANSPORT_NOT_IN_FINLAND")
+                || lastEventStr.equals("Lähetys on matkalla kohdemaahan")
+                || lastEventStr.equals("Lähetys on rekisteröity.")
+                || lastEventStr.equals("Lähetys on lähtenyt varastolta")
+                || lastEventStr.equals("Lähetys on saapunut varastolle")
+                || lastEventStr.equals("Lähetys ei ole vielä saapunut Postille, odotathan")
+        ) {
             return new PhaseNumberString("1", "IN_TRANSPORT_NOT_IN_FINLAND");
 
 
@@ -58,6 +64,7 @@ public class PhaseNumber {
                 || (lastEventStr.contains("UPS Access Point") && !lastEventStr.contains("toimipaikkaan odottaa"))
                 || lastEventStr.contains("Lähetys on noudettavissa")
                 || lastEventStr.contains("Lähetimme vastaanottajalle viestin lähetyksen saapumisesta")
+                || lastEventStr.contains("toimitettu noutopisteeseen")
         )) {
             return new PhaseNumberString("3", "READY_FOR_PICKUP");
 


### PR DESCRIPTION
There is very retarded (made by me) handling for statuses at CustomParcelsAdapterV2.java

Problem is not "phase.length() ==" checking but additional checks for latest event descriptions. This is already handled at parcel update thread so would probably be better to **remove this event checking completely from CustomParcelsAdapterV2 ?**

My parcel was "delivered" after I got parcel but then events were updated with "ilmoitus tekstiviestillä" later by parcel company tracking which lead paketin seuranta to think its "ready for pickup".

I would take risk and clean all this junk away because now theres this mixed handling in two places.