### PR TITLE
Tracking details to follow language

### DIFF
--- a/app/src/main/java/com/nitramite/courier/ArraPakettiStrategy.java
+++ b/app/src/main/java/com/nitramite/courier/ArraPakettiStrategy.java
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint;
 import android.util.Log;
 
 import com.nitramite.paketinseuranta.EventObject;
+import com.nitramite.utils.Locale;
 
 import org.jetbrains.annotations.NonNls;
 import org.json.JSONArray;
@@ -34,7 +35,7 @@ public class ArraPakettiStrategy implements CourierStrategy {
 
     @SuppressWarnings("HardCodedStringLiteral")
     @Override
-    public ParcelObject execute(String parcelCode) {
+    public ParcelObject execute(String parcelCode, final Locale locale) {
         ParcelObject parcelObject = new ParcelObject(parcelCode);
         ArrayList<EventObject> eventObjects = new ArrayList<>();
         try {

--- a/app/src/main/java/com/nitramite/courier/BringStrategy.java
+++ b/app/src/main/java/com/nitramite/courier/BringStrategy.java
@@ -12,6 +12,7 @@ import android.annotation.SuppressLint;
 import android.util.Log;
 
 import com.nitramite.paketinseuranta.EventObject;
+import com.nitramite.utils.Locale;
 
 import org.jetbrains.annotations.NonNls;
 import org.json.JSONArray;
@@ -37,7 +38,7 @@ public class BringStrategy implements CourierStrategy {
 
     @SuppressWarnings("HardCodedStringLiteral")
     @Override
-    public ParcelObject execute(String parcelCode) {
+    public ParcelObject execute(String parcelCode, final Locale locale) {
 
         // Api url
         String url = "https://tracking.bring.com/tracking/api/fetch/" + parcelCode + "?lang=en";

--- a/app/src/main/java/com/nitramite/courier/CainiaoStrategy.java
+++ b/app/src/main/java/com/nitramite/courier/CainiaoStrategy.java
@@ -13,6 +13,7 @@ import android.util.Log;
 
 import com.nitramite.paketinseuranta.EventObject;
 import com.nitramite.paketinseuranta.PhaseNumber;
+import com.nitramite.utils.Locale;
 import com.nitramite.utils.Utils;
 
 import org.jetbrains.annotations.NonNls;
@@ -54,7 +55,7 @@ public class CainiaoStrategy implements CourierStrategy {
 
     @SuppressWarnings("HardCodedStringLiteral")
     @Override
-    public ParcelObject execute(String parcelCode) {
+    public ParcelObject execute(String parcelCode, final Locale locale) {
         ParcelObject parcelObject = new ParcelObject(parcelCode);
 
         try {

--- a/app/src/main/java/com/nitramite/courier/ChinaPostAirMailStrategy.java
+++ b/app/src/main/java/com/nitramite/courier/ChinaPostAirMailStrategy.java
@@ -2,6 +2,7 @@ package com.nitramite.courier;
 
 import android.util.Log;
 import com.nitramite.paketinseuranta.EventObject;
+import com.nitramite.utils.Locale;
 
 import org.jetbrains.annotations.NonNls;
 import org.jsoup.Jsoup;
@@ -19,7 +20,7 @@ public class ChinaPostAirMailStrategy implements CourierStrategy {
 
     @SuppressWarnings("HardCodedStringLiteral")
     @Override
-    public ParcelObject execute(String parcelCode) {
+    public ParcelObject execute(String parcelCode, final Locale locale) {
         ParcelObject parcelObject = new ParcelObject(parcelCode);
         ArrayList<EventObject> eventObjects = new ArrayList<>();
         try {

--- a/app/src/main/java/com/nitramite/courier/Courier.java
+++ b/app/src/main/java/com/nitramite/courier/Courier.java
@@ -1,5 +1,7 @@
 package com.nitramite.courier;
 
+import com.nitramite.utils.Locale;
+
 import org.jetbrains.annotations.NonNls;
 
 /**
@@ -27,8 +29,8 @@ public class Courier {
     }
 
     // Execute selected courier strategy
-    public ParcelObject executeCourierStrategy(final String parcelCode) {
-        return this.courierStrategy.execute(parcelCode);
+    public ParcelObject executeCourierStrategy(final String parcelCode, final Locale locale) {
+        return this.courierStrategy.execute(parcelCode, locale);
     }
 
 } // End of class

--- a/app/src/main/java/com/nitramite/courier/CourierStrategy.java
+++ b/app/src/main/java/com/nitramite/courier/CourierStrategy.java
@@ -1,8 +1,10 @@
 package com.nitramite.courier;
 
+import com.nitramite.utils.Locale;
+
 @FunctionalInterface
 public interface CourierStrategy {
 
-    ParcelObject execute(final String parcelCode); // Execute strategy interface
+    ParcelObject execute(final String parcelCode, final Locale locale); // Execute strategy interface
 
 } // End of interface

--- a/app/src/main/java/com/nitramite/courier/DHLActiveTrackingStrategy.java
+++ b/app/src/main/java/com/nitramite/courier/DHLActiveTrackingStrategy.java
@@ -3,6 +3,7 @@ package com.nitramite.courier;
 import android.annotation.SuppressLint;
 
 import com.nitramite.paketinseuranta.EventObject;
+import com.nitramite.utils.Locale;
 
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -33,7 +34,7 @@ public class DHLActiveTrackingStrategy implements CourierStrategy {
 
 
     @Override
-    public ParcelObject execute(String parcelCode) {
+    public ParcelObject execute(String parcelCode, final Locale locale) {
         ParcelObject parcelObject = new ParcelObject(parcelCode);
         ArrayList<EventObject> eventObjects = new ArrayList<>();
         try {

--- a/app/src/main/java/com/nitramite/courier/DHLAmazonStrategy.java
+++ b/app/src/main/java/com/nitramite/courier/DHLAmazonStrategy.java
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint;
 import android.util.Log;
 
 import com.nitramite.paketinseuranta.EventObject;
+import com.nitramite.utils.Locale;
 
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -33,7 +34,7 @@ public class DHLAmazonStrategy implements CourierStrategy {
     private static final String TAG = "DHLAmazonStrategy";
 
     @Override
-    public ParcelObject execute(String parcelCode) {
+    public ParcelObject execute(String parcelCode, final Locale locale) {
         ParcelObject parcelObject = new ParcelObject(parcelCode);
         ArrayList<EventObject> eventObjects = new ArrayList<>();
         try {

--- a/app/src/main/java/com/nitramite/courier/DHLExpressStrategy.java
+++ b/app/src/main/java/com/nitramite/courier/DHLExpressStrategy.java
@@ -31,7 +31,7 @@ public class DHLExpressStrategy implements CourierStrategy {
 
 
     @Override
-    public ParcelObject execute(String parcelCode) {
+    public ParcelObject execute(String parcelCode, final com.nitramite.utils.Locale locale) {
         ParcelObject parcelObject = new ParcelObject(parcelCode);
         ArrayList<EventObject> eventObjects = new ArrayList<>();
         try {

--- a/app/src/main/java/com/nitramite/courier/DHLExpressStrategy.java
+++ b/app/src/main/java/com/nitramite/courier/DHLExpressStrategy.java
@@ -35,7 +35,7 @@ public class DHLExpressStrategy implements CourierStrategy {
         ParcelObject parcelObject = new ParcelObject(parcelCode);
         ArrayList<EventObject> eventObjects = new ArrayList<>();
         try {
-            String url = "https://www.dhl.fi/shipmentTracking?AWB=" + parcelCode + "&countryCode=fi&languageCode=fi";
+            String url = "https://www.dhl.fi/shipmentTracking?AWB=" + parcelCode + "&countryCode=fi&languageCode=" + (locale == com.nitramite.utils.Locale.FI ? "fi" : "en");
 
             OkHttpClient client = new OkHttpClient();
             Request request = new Request.Builder()
@@ -83,12 +83,12 @@ public class DHLExpressStrategy implements CourierStrategy {
                         @SuppressLint("SimpleDateFormat") DateFormat tf2 = new SimpleDateFormat("dd.MM.yyyy");
                         final JSONObject deliveryTimeObject = jsonChildNode.getJSONObject("edd");
                         String date = deliveryTimeObject.optString("date");
-                        String monthNumber = Utils.finnishMonthStringToMonthNumber(date);
-                        String dayNumber = date.replace(" ", "")
-                                .replace("tammikuu", "").replace("helmikuu", "").replace("maaliskuu", "").replace("huhtikuu", "")
-                                .replace("toukokuu", "").replace("kesäkuu", "").replace("heinäkuu", "").replace("elokuu", "")
-                                .replace("syyskuu", "").replace("lokakuu", "").replace("marraskuu", "").replace("joulukuu", "")
-                                .split(",")[1];
+                        String monthNumber = Utils.monthStringToMonthNumber(date);
+
+                        String dayNumber = date.replace(" ", "");
+                        dayNumber = replaceMonths(dayNumber);
+                        dayNumber = dayNumber.split(",")[1];
+
                         String yearNumber = date.replace(" ", "").split(",")[2];
                         Date estimateDeliveryDate = tf1.parse(yearNumber + "-" + monthNumber + "-" + dayNumber);
                         //Log.i(TAG, yearNumber + "-" + monthNumber + "-" + dayNumber);
@@ -112,12 +112,10 @@ public class DHLExpressStrategy implements CourierStrategy {
                     // Date
                     // example: "maanantai, heinäkuu 16, 2018 "
                     String date = checkPointObject.getString("date");
-                    String monthNumber = Utils.finnishMonthStringToMonthNumber(date);
-                    String dayNumber = date.replace(" ", "")
-                            .replace("tammikuu", "").replace("helmikuu", "").replace("maaliskuu", "").replace("huhtikuu", "")
-                            .replace("toukokuu", "").replace("kesäkuu", "").replace("heinäkuu", "").replace("elokuu", "")
-                            .replace("syyskuu", "").replace("lokakuu", "").replace("marraskuu", "").replace("joulukuu", "")
-                            .split(",")[1];
+                    String monthNumber = Utils.monthStringToMonthNumber(date);
+                    String dayNumber = date.replace(" ", "");
+                    dayNumber = replaceMonths(dayNumber);
+                    dayNumber = dayNumber.split(",")[1];
                     String yearNumber = date.replace(" ", "").split(",")[2];
                     String time = checkPointObject.getString("time");
                     Date apiDate = apiDateFormat.parse(yearNumber + "-" + monthNumber + "-" + dayNumber + " " + time);
@@ -141,6 +139,35 @@ public class DHLExpressStrategy implements CourierStrategy {
             e.printStackTrace();
         }
         return parcelObject;
+    }
+
+
+    private String replaceMonths(String input) {
+        return input
+                .replace("tammikuu", "")
+                .replace("helmikuu", "")
+                .replace("maaliskuu", "")
+                .replace("huhtikuu", "")
+                .replace("toukokuu", "")
+                .replace("kesäkuu", "")
+                .replace("heinäkuu", "")
+                .replace("elokuu", "")
+                .replace("syyskuu", "")
+                .replace("lokakuu", "")
+                .replace("marraskuu", "")
+                .replace("joulukuu", "")
+                .replace("January", "")
+                .replace("February", "")
+                .replace("March", "")
+                .replace("April", "")
+                .replace("May", "")
+                .replace("June", "")
+                .replace("July", "")
+                .replace("August", "")
+                .replace("September", "")
+                .replace("October", "")
+                .replace("November", "")
+                .replace("December", "");
     }
 
 

--- a/app/src/main/java/com/nitramite/courier/DpdStrategy.java
+++ b/app/src/main/java/com/nitramite/courier/DpdStrategy.java
@@ -12,6 +12,7 @@ import android.util.Log;
 
 import com.nitramite.paketinseuranta.EventObject;
 import com.nitramite.paketinseuranta.PhaseNumber;
+import com.nitramite.utils.Locale;
 import com.nitramite.utils.OkHttpUtils;
 
 import org.json.JSONArray;
@@ -64,7 +65,7 @@ public class DpdStrategy implements CourierStrategy {
 
     @SuppressWarnings("ConstantConditions")
     @Override
-    public ParcelObject execute(String parcelCode) {
+    public ParcelObject execute(String parcelCode, final Locale locale) {
         ParcelObject parcelObject = new ParcelObject(parcelCode);
 
         try {

--- a/app/src/main/java/com/nitramite/courier/FedExStrategy.java
+++ b/app/src/main/java/com/nitramite/courier/FedExStrategy.java
@@ -32,7 +32,7 @@ public class FedExStrategy implements CourierStrategy {
     public static final MediaType JSON = MediaType.get("application/json; charset=utf-8");
 
     @Override
-    public ParcelObject execute(String parcelCode) {
+    public ParcelObject execute(String parcelCode, final com.nitramite.utils.Locale locale) {
         ParcelObject parcelObject = new ParcelObject(parcelCode);
         ArrayList<EventObject> eventObjects = new ArrayList<>();
         try {

--- a/app/src/main/java/com/nitramite/courier/FourPXStrategy.java
+++ b/app/src/main/java/com/nitramite/courier/FourPXStrategy.java
@@ -15,6 +15,7 @@ import com.nitramite.courier.fourpx.FourPXEvent;
 import com.nitramite.courier.fourpx.FourPXParcel;
 import com.nitramite.courier.fourpx.ListTrackResponse;
 import com.nitramite.paketinseuranta.EventObject;
+import com.nitramite.utils.Locale;
 import com.nitramite.utils.OkHttpUtils;
 
 import org.json.JSONArray;
@@ -76,7 +77,7 @@ public class FourPXStrategy implements CourierStrategy {
     }
 
     @Override
-    public ParcelObject execute(String parcelCode) {
+    public ParcelObject execute(String parcelCode, final Locale locale) {
         ParcelObject parcelObject = new ParcelObject(parcelCode);
 
         try {

--- a/app/src/main/java/com/nitramite/courier/GlsStrategy.java
+++ b/app/src/main/java/com/nitramite/courier/GlsStrategy.java
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint;
 import android.util.Log;
 
 import com.nitramite.paketinseuranta.EventObject;
+import com.nitramite.utils.Locale;
 import com.nitramite.utils.Utils;
 
 import org.json.JSONArray;
@@ -28,7 +29,7 @@ public class GlsStrategy implements CourierStrategy {
     private static final String TAG = "GlsStrategy";
 
     @Override
-    public ParcelObject execute(final String parcelCode) {
+    public ParcelObject execute(final String parcelCode, final Locale locale) {
         ParcelObject parcelObject = new ParcelObject(parcelCode);
         ArrayList<EventObject> eventObjects = new ArrayList<>();
         try {

--- a/app/src/main/java/com/nitramite/courier/MatkahuoltoStrategy.java
+++ b/app/src/main/java/com/nitramite/courier/MatkahuoltoStrategy.java
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint;
 import android.util.Log;
 
 import com.nitramite.paketinseuranta.EventObject;
+import com.nitramite.utils.Locale;
 
 
 import org.json.JSONArray;
@@ -31,7 +32,7 @@ public class MatkahuoltoStrategy implements CourierStrategy {
 
 
     @Override
-    public ParcelObject execute(String parcelCode) {
+    public ParcelObject execute(String parcelCode, final Locale locale) {
         ParcelObject parcelObject = new ParcelObject(parcelCode);
         ArrayList<EventObject> eventObjects = new ArrayList<>();
         try {

--- a/app/src/main/java/com/nitramite/courier/MatkahuoltoStrategy.java
+++ b/app/src/main/java/com/nitramite/courier/MatkahuoltoStrategy.java
@@ -28,7 +28,7 @@ import okhttp3.Response;
 public class MatkahuoltoStrategy implements CourierStrategy {
 
     // Logging
-    private static final String TAG = "MatkahuoltoStrategy";
+    private static final String TAG = MatkahuoltoStrategy.class.getSimpleName();
 
 
     @Override
@@ -36,7 +36,7 @@ public class MatkahuoltoStrategy implements CourierStrategy {
         ParcelObject parcelObject = new ParcelObject(parcelCode);
         ArrayList<EventObject> eventObjects = new ArrayList<>();
         try {
-            String url = "https://www.api.matkahuolto.io/search/trackingInfo?language=fi&parcelNumber=" + parcelCode;
+            String url = "https://www.api.matkahuolto.io/search/trackingInfo?language=" + (locale == Locale.FI ? "fi" : "en") + "&parcelNumber=" + parcelCode;
 
             OkHttpClient client = new OkHttpClient();
             Request request = new Request.Builder()

--- a/app/src/main/java/com/nitramite/courier/PostNordStrategy.java
+++ b/app/src/main/java/com/nitramite/courier/PostNordStrategy.java
@@ -27,14 +27,14 @@ import okhttp3.Response;
 public class PostNordStrategy implements CourierStrategy {
 
     // Logging
-    private static final String TAG = "PostNordStrategy";
+    private static final String TAG = PostNordStrategy.class.getSimpleName();
 
     @Override
     public ParcelObject execute(String parcelCode, final Locale locale) {
         ParcelObject parcelObject = new ParcelObject(parcelCode);
         ArrayList<EventObject> eventObjects = new ArrayList<>();
         try {
-            String url = "https://www.postnord.fi/api/pnmw/shipment/" + parcelCode + "/fi";
+            String url = "https://www.postnord.fi/api/pnmw/shipment/" + parcelCode + "/" + (locale == Locale.FI ? "fi" : "en");
 
             OkHttpClient client = new OkHttpClient();
             Request request = new Request.Builder()

--- a/app/src/main/java/com/nitramite/courier/PostNordStrategy.java
+++ b/app/src/main/java/com/nitramite/courier/PostNordStrategy.java
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint;
 import android.util.Log;
 
 import com.nitramite.paketinseuranta.EventObject;
+import com.nitramite.utils.Locale;
 import com.nitramite.utils.Utils;
 
 import org.json.JSONArray;
@@ -29,7 +30,7 @@ public class PostNordStrategy implements CourierStrategy {
     private static final String TAG = "PostNordStrategy";
 
     @Override
-    public ParcelObject execute(String parcelCode) {
+    public ParcelObject execute(String parcelCode, final Locale locale) {
         ParcelObject parcelObject = new ParcelObject(parcelCode);
         ArrayList<EventObject> eventObjects = new ArrayList<>();
         try {

--- a/app/src/main/java/com/nitramite/courier/PostiStrategy.java
+++ b/app/src/main/java/com/nitramite/courier/PostiStrategy.java
@@ -107,7 +107,7 @@ public class PostiStrategy implements CourierStrategy {
                 if (jsonChildNode.getJSONObject("product").has("name")) {
                     if (!jsonChildNode.getJSONObject("product").getString("name").contains("null")) {
                         parcelObject.setProduct(
-                                jsonChildNode.getJSONObject("product").getJSONObject("name").optString("fi")
+                                jsonChildNode.getJSONObject("product").getJSONObject("name").optString(locale == Locale.FI? "fi" : "en")
                         );
                     }
                 }
@@ -120,7 +120,7 @@ public class PostiStrategy implements CourierStrategy {
                         JSONObject extraServiceNameObj = extraServiceObj.optJSONObject("name");
                         if (extraServiceNameObj != null) {
                             parcelObject.setExtraServices(
-                                    extraServiceNameObj.optString("fi")
+                                    extraServiceNameObj.optString(locale == Locale.FI? "fi" : "en")
                             );
                         }
                     }
@@ -159,7 +159,7 @@ public class PostiStrategy implements CourierStrategy {
                     JSONObject eventObj = eventJsonObj.optJSONObject("description");
                     String eventDescription = "-";
                     if (eventObj != null) {
-                        eventDescription = eventObj.optString("fi");
+                        eventDescription = eventObj.optString(locale == Locale.FI? "fi" : "en");
                     }
 
                     // Pass to object

--- a/app/src/main/java/com/nitramite/courier/PostiStrategy.java
+++ b/app/src/main/java/com/nitramite/courier/PostiStrategy.java
@@ -4,6 +4,8 @@ import android.annotation.SuppressLint;
 import android.util.Log;
 
 import com.nitramite.paketinseuranta.EventObject;
+import com.nitramite.utils.Locale;
+import com.nitramite.utils.LocaleUtils;
 import com.nitramite.utils.Utils;
 
 import org.json.JSONArray;
@@ -30,7 +32,7 @@ public class PostiStrategy implements CourierStrategy {
     private static final String TAG = "PostiStrategy";
 
     @Override
-    public ParcelObject execute(final String parcelCode) {
+    public ParcelObject execute(final String parcelCode, final Locale locale) {
         ParcelObject parcelObject = new ParcelObject(parcelCode);
         ArrayList<EventObject> eventObjects = new ArrayList<>();
         try {

--- a/app/src/main/java/com/nitramite/courier/UPSStrategy.java
+++ b/app/src/main/java/com/nitramite/courier/UPSStrategy.java
@@ -6,6 +6,7 @@ import android.util.Log;
 import com.google.gson.JsonArray;
 import com.nitramite.courier.ups.UpsTokenPair;
 import com.nitramite.paketinseuranta.EventObject;
+import com.nitramite.utils.Locale;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -42,7 +43,7 @@ public class UPSStrategy implements CourierStrategy {
 
 
     @Override
-    public ParcelObject execute(String parcelCode) {
+    public ParcelObject execute(String parcelCode, final Locale locale) {
         // Expected phase strings on site
         final String wordDelivered = "TOIMITETTU";
         final String wordInTransport = "Tilaus käsitelty: Valmis UPS:lle";

--- a/app/src/main/java/com/nitramite/courier/USPSStrategy.java
+++ b/app/src/main/java/com/nitramite/courier/USPSStrategy.java
@@ -22,7 +22,7 @@ public class USPSStrategy implements CourierStrategy {
 
 
     @Override
-    public ParcelObject execute(String parcelCode) {
+    public ParcelObject execute(String parcelCode, final com.nitramite.utils.Locale locale) {
         ParcelObject parcelObject = new ParcelObject(parcelCode);
         ArrayList<EventObject> eventObjects = new ArrayList<>();
 

--- a/app/src/main/java/com/nitramite/courier/YanwenStrategy.java
+++ b/app/src/main/java/com/nitramite/courier/YanwenStrategy.java
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint;
 import android.util.Log;
 
 import com.nitramite.paketinseuranta.EventObject;
+import com.nitramite.utils.Locale;
 
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
@@ -28,7 +29,7 @@ public class YanwenStrategy implements CourierStrategy {
 
 
     @Override
-    public ParcelObject execute(String parcelCode) {
+    public ParcelObject execute(String parcelCode, final Locale locale) {
         ParcelObject parcelObject = new ParcelObject(parcelCode);
         try {
             // Get website with tracking info

--- a/app/src/main/java/com/nitramite/paketinseuranta/CarrierDetectorTask.java
+++ b/app/src/main/java/com/nitramite/paketinseuranta/CarrierDetectorTask.java
@@ -27,6 +27,7 @@ import com.nitramite.courier.PostiStrategy;
 import com.nitramite.courier.UPSStrategy;
 import com.nitramite.courier.YanwenStrategy;
 import com.nitramite.utils.CarrierUtils;
+import com.nitramite.utils.Locale;
 
 import java.util.ArrayList;
 
@@ -38,11 +39,13 @@ public class CarrierDetectorTask extends AsyncTask<String, String, String> {
     private static final String TAG = "CarrierDetectorTask";
     private CarrierDetectorTaskInterface listener;
     private String parcelCode;
+    private Locale locale;
 
     // Constructor
-    CarrierDetectorTask(CarrierDetectorTaskInterface listener, final String parcelCode) {
+    CarrierDetectorTask(CarrierDetectorTaskInterface listener, final String parcelCode, Locale locale_) {
         this.listener = listener;
         this.parcelCode = parcelCode;
+        this.locale = locale_;
     }
 
     @Override
@@ -107,7 +110,7 @@ public class CarrierDetectorTask extends AsyncTask<String, String, String> {
             progress = progress + increment;
             try {
                 courier.setCourierStrategy(courierStrategies.get(i));
-                parcelObject = courier.executeCourierStrategy((this.parcelCode));
+                parcelObject = courier.executeCourierStrategy((this.parcelCode), locale);
                 if (parcelObject.getIsFound()) {
                     listener.onCarrierDetected(courierIntegers.get(i));
                 }

--- a/app/src/main/java/com/nitramite/paketinseuranta/Parcel.java
+++ b/app/src/main/java/com/nitramite/paketinseuranta/Parcel.java
@@ -1267,14 +1267,22 @@ public class Parcel extends AppCompatActivity implements OnMapReadyCallback, Swi
             if (autoStart) {
                 detectCarrierProgressBar.setVisibility(View.VISIBLE);
                 detectCarrierProgressBar.setProgress(0);
-                carrierDetectorTask = new CarrierDetectorTask(Parcel.this, parcelDataArray.get(0));
+                carrierDetectorTask = new CarrierDetectorTask(
+                        Parcel.this,
+                        parcelDataArray.get(0),
+                        localeUtils.getLocale(this)
+                );
                 carrierDetectorTask.execute();
                 startDetectorBtn.setVisibility(View.GONE);
             }
             startDetectorBtn.setOnClickListener(view -> {
                 detectCarrierProgressBar.setVisibility(View.VISIBLE);
                 detectCarrierProgressBar.setProgress(0);
-                carrierDetectorTask = new CarrierDetectorTask(Parcel.this, parcelDataArray.get(0));
+                carrierDetectorTask = new CarrierDetectorTask(
+                        Parcel.this,
+                        parcelDataArray.get(0),
+                        localeUtils.getLocale(this)
+                );
                 carrierDetectorTask.execute();
             });
             closeDialogBtn.setOnClickListener(view -> {

--- a/app/src/main/java/com/nitramite/paketinseuranta/updater/UpdaterLogic.java
+++ b/app/src/main/java/com/nitramite/paketinseuranta/updater/UpdaterLogic.java
@@ -48,6 +48,7 @@ import com.nitramite.paketinseuranta.PhaseNumber;
 import com.nitramite.paketinseuranta.PhaseNumberString;
 import com.nitramite.paketinseuranta.R;
 import com.nitramite.utils.CarrierUtils;
+import com.nitramite.utils.Locale;
 import com.nitramite.utils.LocaleUtils;
 import com.nitramite.utils.Utils;
 
@@ -61,7 +62,11 @@ public class UpdaterLogic {
     private static String TAG = "UpdaterLogic";
 
     public static Thread getUpdaterThread(Context context, LocaleUtils localeUtils, boolean enableNotifications, boolean updateFailedFirst, int serviceMode, String PARCEL_ID, DatabaseHelper databaseHelper) {
+
         List<ParcelService.ParcelServiceParcelItem> parcelServiceParcelItems = new ArrayList<>();
+
+        Locale locale = localeUtils.getLocale(context);
+
         return new Thread(new Runnable() {
             @SuppressWarnings("SpellCheckingInspection")
             @Override
@@ -111,7 +116,7 @@ public class UpdaterLogic {
                                 case CarrierUtils.CARRIER_POSTI:
                                 case CarrierUtils.CARRIER_CHINA:
                                     courier.setCourierStrategy(new PostiStrategy());
-                                    parcelObject = courier.executeCourierStrategy(parcelServiceParcelItems.get(i).getParcelCodeItem());
+                                    parcelObject = courier.executeCourierStrategy(parcelServiceParcelItems.get(i).getParcelCodeItem(), locale);
                                     Log.i(TAG, "# Running Posti #");
 
                                     break;
@@ -119,97 +124,97 @@ public class UpdaterLogic {
                                 case CarrierUtils.CARRIER_MATKAHUOLTO:
                                     Log.i(TAG, "# Running Matkahuolto #");
                                     courier.setCourierStrategy(new MatkahuoltoStrategy());
-                                    parcelObject = courier.executeCourierStrategy(parcelServiceParcelItems.get(i).getParcelCodeItem());
+                                    parcelObject = courier.executeCourierStrategy(parcelServiceParcelItems.get(i).getParcelCodeItem(), locale);
                                     break;
                                 // DHL Express
                                 case CarrierUtils.CARRIER_DHL_EXPRESS:
                                     Log.i(TAG, "# Running DHL #");
                                     courier.setCourierStrategy(new DHLExpressStrategy());
-                                    parcelObject = courier.executeCourierStrategy(parcelServiceParcelItems.get(i).getParcelCodeItem());
+                                    parcelObject = courier.executeCourierStrategy(parcelServiceParcelItems.get(i).getParcelCodeItem(), locale);
                                     break;
                                 // UPS
                                 case CarrierUtils.CARRIER_UPS:
                                     Log.i(TAG, "# Running UPS #");
                                     courier.setCourierStrategy(new UPSStrategy());
-                                    parcelObject = courier.executeCourierStrategy(parcelServiceParcelItems.get(i).getParcelCodeItem());
+                                    parcelObject = courier.executeCourierStrategy(parcelServiceParcelItems.get(i).getParcelCodeItem(), locale);
                                     break;
                                 // FedEx
                                 case CarrierUtils.CARRIER_FEDEX:
                                     Log.i(TAG, "# Running FedEx #");
                                     courier.setCourierStrategy(new FedExStrategy());
-                                    parcelObject = courier.executeCourierStrategy(parcelServiceParcelItems.get(i).getParcelCodeItem());
+                                    parcelObject = courier.executeCourierStrategy(parcelServiceParcelItems.get(i).getParcelCodeItem(), locale);
                                     break;
                                 // PostNord
                                 case CarrierUtils.CARRIER_POSTNORD:
                                     Log.i(TAG, "# Running PostNord #");
                                     courier.setCourierStrategy(new PostNordStrategy());
-                                    parcelObject = courier.executeCourierStrategy(parcelServiceParcelItems.get(i).getParcelCodeItem());
+                                    parcelObject = courier.executeCourierStrategy(parcelServiceParcelItems.get(i).getParcelCodeItem(), locale);
                                     break;
                                 // ArraPaketti
                                 case CarrierUtils.CARRIER_ARRA_PAKETTI:
                                     Log.i(TAG, "# Running ArraPaketti #");
                                     courier.setCourierStrategy(new ArraPakettiStrategy());
-                                    parcelObject = courier.executeCourierStrategy(parcelServiceParcelItems.get(i).getParcelCodeItem());
+                                    parcelObject = courier.executeCourierStrategy(parcelServiceParcelItems.get(i).getParcelCodeItem(), locale);
                                     break;
                                 // DHL Amazon
                                 case CarrierUtils.CARRIER_DHL_AMAZON:
                                     Log.i(TAG, "# Running DHL Amazon #");
                                     courier.setCourierStrategy(new DHLAmazonStrategy());
-                                    parcelObject = courier.executeCourierStrategy(parcelServiceParcelItems.get(i).getParcelCodeItem());
+                                    parcelObject = courier.executeCourierStrategy(parcelServiceParcelItems.get(i).getParcelCodeItem(), locale);
                                     break;
                                 // DHL Active Tracking
                                 case CarrierUtils.CARRIER_DHL_ACTIVE_TRACKING:
                                     Log.i(TAG, "# Running DHL Active Tracking #");
                                     courier.setCourierStrategy(new DHLActiveTrackingStrategy());
-                                    parcelObject = courier.executeCourierStrategy(parcelServiceParcelItems.get(i).getParcelCodeItem());
+                                    parcelObject = courier.executeCourierStrategy(parcelServiceParcelItems.get(i).getParcelCodeItem(), locale);
                                     break;
                                 // USPS (United States Postal Service)
                                 case CarrierUtils.CARRIER_USPS:
                                     Log.i(TAG, "# Running USPS #");
                                     courier.setCourierStrategy(new USPSStrategy());
-                                    parcelObject = courier.executeCourierStrategy(parcelServiceParcelItems.get(i).getParcelCodeItem());
+                                    parcelObject = courier.executeCourierStrategy(parcelServiceParcelItems.get(i).getParcelCodeItem(), locale);
                                     break;
                                 // Yanwen
                                 case CarrierUtils.CARRIER_YANWEN:
                                     Log.i(TAG, "# Running Yanwen #");
                                     courier.setCourierStrategy(new YanwenStrategy());
-                                    parcelObject = courier.executeCourierStrategy(parcelServiceParcelItems.get(i).getParcelCodeItem());
+                                    parcelObject = courier.executeCourierStrategy(parcelServiceParcelItems.get(i).getParcelCodeItem(), locale);
                                     break;
                                 // GLS
                                 case CarrierUtils.CARRIER_GLS:
                                     Log.i(TAG, "# Running GLS #");
                                     courier.setCourierStrategy(new GlsStrategy());
-                                    parcelObject = courier.executeCourierStrategy(parcelServiceParcelItems.get(i).getParcelCodeItem());
+                                    parcelObject = courier.executeCourierStrategy(parcelServiceParcelItems.get(i).getParcelCodeItem(), locale);
                                     break;
                                 // Cainiao
                                 case CarrierUtils.CARRIER_CAINIAO:
                                     Log.i(TAG, "# Running Cainiao #");
                                     courier.setCourierStrategy(new CainiaoStrategy());
-                                    parcelObject = courier.executeCourierStrategy(parcelServiceParcelItems.get(i).getParcelCodeItem());
+                                    parcelObject = courier.executeCourierStrategy(parcelServiceParcelItems.get(i).getParcelCodeItem(), locale);
                                     break;
                                 // 4PX
                                 case CarrierUtils.CARRIER_4PX:
                                     Log.i(TAG, "# Running 4PX #");
                                     courier.setCourierStrategy(new FourPXStrategy());
-                                    parcelObject = courier.executeCourierStrategy(parcelServiceParcelItems.get(i).getParcelCodeItem());
+                                    parcelObject = courier.executeCourierStrategy(parcelServiceParcelItems.get(i).getParcelCodeItem(), locale);
                                     break;
                                 // China Post Registered Air Mail
                                 case CarrierUtils.CARRIER_CPRAM:
                                     Log.i(TAG, "# Running China Post Registered Air Mail #");
                                     courier.setCourierStrategy(new ChinaPostAirMailStrategy());
-                                    parcelObject = courier.executeCourierStrategy(parcelServiceParcelItems.get(i).getParcelCodeItem());
+                                    parcelObject = courier.executeCourierStrategy(parcelServiceParcelItems.get(i).getParcelCodeItem(), locale);
                                     break;
                                 // Bring
                                 case CarrierUtils.CARRIER_BRING:
                                     Log.i(TAG, "# Running Bring #");
                                     courier.setCourierStrategy(new BringStrategy());
-                                    parcelObject = courier.executeCourierStrategy(parcelServiceParcelItems.get(i).getParcelCodeItem());
+                                    parcelObject = courier.executeCourierStrategy(parcelServiceParcelItems.get(i).getParcelCodeItem(), locale);
                                     break;
                                 // DPD
                                 case CarrierUtils.CARRIER_DPD:
                                     Log.i(TAG, "# Running Dpd #");
                                     courier.setCourierStrategy(new DpdStrategy());
-                                    parcelObject = courier.executeCourierStrategy(parcelServiceParcelItems.get(i).getParcelCodeItem());
+                                    parcelObject = courier.executeCourierStrategy(parcelServiceParcelItems.get(i).getParcelCodeItem(), locale);
                                     break;
 
                                 // Handle default case

--- a/app/src/main/java/com/nitramite/utils/Locale.java
+++ b/app/src/main/java/com/nitramite/utils/Locale.java
@@ -1,0 +1,6 @@
+package com.nitramite.utils;
+
+public enum Locale {
+    FI,
+    EN,
+}

--- a/app/src/main/java/com/nitramite/utils/LocaleUtils.java
+++ b/app/src/main/java/com/nitramite/utils/LocaleUtils.java
@@ -7,7 +7,9 @@ import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.os.Build;
 import android.os.LocaleList;
+
 import androidx.preference.PreferenceManager;
+
 import android.util.Log;
 
 import com.nitramite.paketinseuranta.Constants;
@@ -20,7 +22,7 @@ import java.util.Set;
 public class LocaleUtils {
 
     //  Logging
-    private static final String TAG = "LocaleUtils";
+    private static final String TAG = LocaleUtils.class.getSimpleName();
 
 
     /**
@@ -129,6 +131,28 @@ public class LocaleUtils {
         } catch (Exception e) {
             e.printStackTrace();
         }
+    }
+
+
+    /**
+     * Get application current locale
+     * primary one is user manually set one and if null secondary is device global
+     * Also --> what a mess this thing is tarting to be for f sake...
+     *
+     * @return locale enum
+     */
+    public com.nitramite.utils.Locale getLocale(Context context) {
+        String ul = getLocaleString(context);
+        String dl = Locale.getDefault().getDisplayLanguage();
+        String lang = ul != null ? ul : dl;
+
+        switch (lang) {
+            case "en":
+                return com.nitramite.utils.Locale.EN;
+            case "fi":
+                return com.nitramite.utils.Locale.FI;
+        }
+        return com.nitramite.utils.Locale.FI;
     }
 
 

--- a/app/src/main/java/com/nitramite/utils/Utils.java
+++ b/app/src/main/java/com/nitramite/utils/Utils.java
@@ -64,30 +64,30 @@ public class Utils {
 
 
     // Month string to corresponding number
-    public static String finnishMonthStringToMonthNumber(String dateString) {
-        if (dateString.contains("tammikuu")) {
+    public static String monthStringToMonthNumber(String dateString) {
+        if (dateString.contains("tammikuu") || dateString.contains("January")) {
             return "01";
-        } else if (dateString.contains("helmikuu")) {
+        } else if (dateString.contains("helmikuu") || dateString.contains("February")) {
             return "02";
-        } else if (dateString.contains("maaliskuu")) {
+        } else if (dateString.contains("maaliskuu") || dateString.contains("March")) {
             return "03";
-        } else if (dateString.contains("huhtikuu")) {
+        } else if (dateString.contains("huhtikuu") || dateString.contains("April")) {
             return "04";
-        } else if (dateString.contains("toukokuu")) {
+        } else if (dateString.contains("toukokuu") || dateString.contains("May")) {
             return "05";
-        } else if (dateString.contains("kesäkuu")) {
+        } else if (dateString.contains("kesäkuu") || dateString.contains("June")) {
             return "06";
-        } else if (dateString.contains("heinäkuu")) {
+        } else if (dateString.contains("heinäkuu") || dateString.contains("July")) {
             return "07";
-        } else if (dateString.contains("elokuu")) {
+        } else if (dateString.contains("elokuu") || dateString.contains("August")) {
             return "08";
-        } else if (dateString.contains("syyskuu")) {
+        } else if (dateString.contains("syyskuu") || dateString.contains("September")) {
             return "09";
-        } else if (dateString.contains("lokakuu")) {
+        } else if (dateString.contains("lokakuu") || dateString.contains("October")) {
             return "10";
-        } else if (dateString.contains("marraskuu")) {
+        } else if (dateString.contains("marraskuu") || dateString.contains("November")) {
             return "11";
-        } else if (dateString.contains("joulukuu")) {
+        } else if (dateString.contains("joulukuu") || dateString.contains("December")) {
             return "12";
         }
         return "0";


### PR DESCRIPTION
Initially follow setting language and secondary option is global device language.

This change was something which is now requested by user but should have been included long time ago.

Problems this change creates for existing users is that some events will be duplicate english and finnish strings but only IF device language is English and/or lang override is not touched or set also to English. Should not be life damaging tho.