### PR TITLE
Add missing back buttons

### DIFF
--- a/app/src/main/java/com/nitramite/paketinseuranta/BackupManager.java
+++ b/app/src/main/java/com/nitramite/paketinseuranta/BackupManager.java
@@ -21,6 +21,8 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
+import android.view.Menu;
+import android.view.MenuItem;
 import android.view.View;
 import android.view.WindowManager;
 import android.widget.Button;
@@ -74,6 +76,12 @@ public class BackupManager extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         localeUtils.setApplicationLanguage(this);
         setContentView(R.layout.activity_backup_manager);
+        setTitle(getString(R.string.backup));
+
+        //noinspection ConstantConditions
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        // getSupportActionBar().setDefaultDisplayHomeAsUpEnabled(true);
+
 
         sharedPreferences = SharedPreferencesUtils.getSharedPreferences(getApplicationContext());
 
@@ -276,6 +284,24 @@ public class BackupManager extends AppCompatActivity {
     private void setLastBackupTakenView() {
         final String lastBackupDateStr = sharedPreferences.getString(Constants.SP_TIMED_BACKUP_LAST_DATE, null);
         lastBackupDate.setText(lastBackupDateStr == null ? getString(R.string.no_timed_backups_taken) : getString(R.string.last_backup) + lastBackupDateStr);
+    }
+
+
+
+    // Menu items
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        // getMenuInflater().inflate(R.menu.menu_archive, menu);
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        int id = item.getItemId();
+        if (id == android.R.id.home) {
+            finish();
+        }
+        return super.onOptionsItemSelected(item);
     }
 
 }

--- a/app/src/main/java/com/nitramite/paketinseuranta/ParcelEditor.java
+++ b/app/src/main/java/com/nitramite/paketinseuranta/ParcelEditor.java
@@ -4,6 +4,7 @@ import android.Manifest;
 import android.app.AlertDialog;
 import android.content.ClipboardManager;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Build;
@@ -58,6 +59,10 @@ public class ParcelEditor extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         localeUtils.setApplicationLanguage(this);
         setContentView(R.layout.activity_parcel_editor);
+
+        //noinspection ConstantConditions
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        // getSupportActionBar().setDefaultDisplayHomeAsUpEnabled(true);
 
         // Get services
         clipboard = (ClipboardManager) getSystemService(Context.CLIPBOARD_SERVICE);
@@ -169,6 +174,9 @@ public class ParcelEditor extends AppCompatActivity {
         if (id == R.id.action_save) {
             this.fragmentTrackedDeliveryInterface.onSaveChangesActionBtnClick();
             return true;
+        }
+        if (id == android.R.id.home) {
+            onBackPressed();
         }
         return super.onOptionsItemSelected(item);
     }

--- a/app/src/main/res/values-fi-rFI/strings.xml
+++ b/app/src/main/res/values-fi-rFI/strings.xml
@@ -282,6 +282,7 @@
     <string name="continue_with_backup_restore">Palauta tietokanta varmuuskopiosta?</string>
     <string name="export_backup">Vie varmuuskopio</string>
     <string name="import_backup">Tuo varmuuskopio</string>
+    <string name="backup">Varmuuskopio</string>
 
 
     <!-- Strings related to Settings -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -282,6 +282,7 @@
     <string name="continue_with_backup_restore">Continue with database restore from backup?</string>
     <string name="export_backup">Export backup</string>
     <string name="import_backup">Import backup</string>
+    <string name="backup">Backup</string>
 
 
     <!-- Strings related to Settings -->


### PR DESCRIPTION
Added missing top bar back buttons for backup and parcel editor since noticed those were missing from these two activities.

Didn't earlier really use them but brought them here to keep app "similar"